### PR TITLE
refactor: Use Blueprints for route organization

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from flask_login import LoginManager
 db = SQLAlchemy()
 migrate = Migrate()
 login_manager = LoginManager()
-login_manager.login_view = 'login' # Or whatever your login route will be
+login_manager.login_view = 'main.login' # Or whatever your login route will be
 
 def create_app(config_class=Config):
     app = Flask(__name__)
@@ -17,17 +17,13 @@ def create_app(config_class=Config):
     migrate.init_app(app, db)
     login_manager.init_app(app)
 
-    from app.models import User # Import User model
+    from .models import User # Import User model
 
     @login_manager.user_loader
     def load_user(id):
         return User.query.get(int(id))
 
-    # Import and register blueprints here if you use them
-    # from app.main import bp as main_bp
-    # app.register_blueprint(main_bp)
-
-    # For now, let's import routes directly for simplicity in early stages
-    from app import routes # Import routes after models and user_loader
+    from .routes import main_bp # Import the Blueprint
+    app.register_blueprint(main_bp) # Register the Blueprint
 
     return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,14 +1,16 @@
-from flask import render_template, redirect, url_for, flash, request, current_app, abort
+from flask import render_template, redirect, url_for, flash, request, abort, Blueprint
 from urllib.parse import urlparse
 from app import db
-from app.forms import LoginForm, RegistrationForm, CameraForm
-from app.models import User, Camera
+from .forms import LoginForm, RegistrationForm, CameraForm
+from .models import User, Camera
 from flask_login import login_user, logout_user, current_user, login_required
 
-@current_app.route('/register', methods=['GET', 'POST'])
+main_bp = Blueprint('main', __name__)
+
+@main_bp.route('/register', methods=['GET', 'POST'])
 def register():
     if current_user.is_authenticated:
-        return redirect(url_for('index')) # Assuming you'll have an 'index' route
+        return redirect(url_for('main.index'))
     form = RegistrationForm()
     if form.validate_on_submit():
         user = User(username=form.username.data, email=form.email.data)
@@ -16,40 +18,40 @@ def register():
         db.session.add(user)
         db.session.commit()
         flash('Congratulations, you are now a registered user!')
-        return redirect(url_for('login'))
+        return redirect(url_for('main.login'))
     return render_template('register.html', title='Register', form=form)
 
-@current_app.route('/login', methods=['GET', 'POST'])
+@main_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('index')) # Assuming 'index' route
+        return redirect(url_for('main.index'))
     form = LoginForm()
     if form.validate_on_submit():
         user = User.query.filter_by(username=form.username.data).first()
         if user is None or not user.check_password(form.password.data):
             flash('Invalid username or password')
-            return redirect(url_for('login'))
+            return redirect(url_for('main.login'))
         login_user(user, remember=form.remember_me.data)
         next_page = request.args.get('next')
         if not next_page or urlparse(next_page).netloc != '':
-            next_page = url_for('dashboard') # Changed from 'index'
+            next_page = url_for('main.dashboard')
         return redirect(next_page)
     return render_template('login.html', title='Sign In', form=form)
 
-@current_app.route('/logout')
+@main_bp.route('/logout')
 def logout():
     logout_user()
-    return redirect(url_for('index')) # Assuming 'index' route
+    return redirect(url_for('main.index'))
 
 # Add a simple index route for now (can be expanded later)
-@current_app.route('/')
-@current_app.route('/index')
+@main_bp.route('/')
+@main_bp.route('/index')
 def index():
     if current_user.is_authenticated:
-        return redirect(url_for('dashboard'))
-    return redirect(url_for('login'))
+        return redirect(url_for('main.dashboard'))
+    return redirect(url_for('main.login'))
 
-@current_app.route('/add_camera', methods=['GET', 'POST'])
+@main_bp.route('/add_camera', methods=['GET', 'POST'])
 @login_required
 def add_camera():
     form = CameraForm()
@@ -58,16 +60,16 @@ def add_camera():
         db.session.add(camera)
         db.session.commit()
         flash('Your camera has been added!')
-        return redirect(url_for('cameras'))
+        return redirect(url_for('main.cameras'))
     return render_template('add_camera.html', title='Add Camera', form=form)
 
-@current_app.route('/cameras')
+@main_bp.route('/cameras')
 @login_required
 def cameras():
     user_cameras = current_user.cameras.all()
     return render_template('cameras.html', title='Your Cameras', cameras=user_cameras)
 
-@current_app.route('/edit_camera/<int:camera_id>', methods=['GET', 'POST'])
+@main_bp.route('/edit_camera/<int:camera_id>', methods=['GET', 'POST'])
 @login_required
 def edit_camera(camera_id):
     camera = Camera.query.get_or_404(camera_id)
@@ -79,13 +81,13 @@ def edit_camera(camera_id):
         camera.rtsp_url = form.rtsp_url.data
         db.session.commit()
         flash('Your camera has been updated!')
-        return redirect(url_for('cameras'))
+        return redirect(url_for('main.cameras'))
     elif request.method == 'GET':
         form.name.data = camera.name
         form.rtsp_url.data = camera.rtsp_url
     return render_template('edit_camera.html', title='Edit Camera', form=form, camera=camera)
 
-@current_app.route('/delete_camera/<int:camera_id>', methods=['POST'])
+@main_bp.route('/delete_camera/<int:camera_id>', methods=['POST'])
 @login_required
 def delete_camera(camera_id):
     camera = Camera.query.get_or_404(camera_id)
@@ -94,25 +96,25 @@ def delete_camera(camera_id):
     db.session.delete(camera)
     db.session.commit()
     flash('Your camera has been deleted.')
-    return redirect(url_for('cameras'))
+    return redirect(url_for('main.cameras'))
 
-@current_app.route('/arm_system', methods=['POST'])
+@main_bp.route('/arm_system', methods=['POST'])
 @login_required
 def arm_system():
     current_user.is_system_armed = True
     db.session.commit()
     flash('System Armed.')
-    return redirect(request.referrer or url_for('index'))
+    return redirect(request.referrer or url_for('main.index'))
 
-@current_app.route('/disarm_system', methods=['POST'])
+@main_bp.route('/disarm_system', methods=['POST'])
 @login_required
 def disarm_system():
     current_user.is_system_armed = False
     db.session.commit()
     flash('System Disarmed.')
-    return redirect(request.referrer or url_for('index'))
+    return redirect(request.referrer or url_for('main.index'))
 
-@current_app.route('/dashboard')
+@main_bp.route('/dashboard')
 @login_required
 def dashboard():
     return render_template('dashboard.html', title='Dashboard')


### PR DESCRIPTION
I refactored your application to use Flask Blueprints for defining and organizing routes. This addresses the 'RuntimeError: Working outside of application context' that occurred when using @current_app.route decorators directly at module import time.

Changes include:
- Modified `app/routes.py`:
    - Created a Blueprint named `main_bp`.
    - Changed all route decorators from `@current_app.route` to `@main_bp.route`.
    - Updated `url_for()` calls to prefix with the blueprint name (e.g., `url_for('main.login')`).
- Modified `app/__init__.py`:
    - Imported `main_bp` from `app.routes`.
    - Registered `main_bp` with the Flask application instance.
    - Updated `login_manager.login_view` to `'main.login'` to correctly point to the login route within the blueprint.

This change improves your application's structure, makes it more modular, and aligns with common Flask best practices, resolving the context error during application startup.